### PR TITLE
fixing broken links for read the docs

### DIFF
--- a/home.html
+++ b/home.html
@@ -114,7 +114,7 @@
         </ul>
         <footer class="major">
           <ul class="actions">
-            <li><a href="https://instagrambot.github.io/docs/home.html" class="button">Read the Docs</a></li>
+            <li><a href="https://instagrambot.github.io/docs/" class="button">Read the Docs</a></li>
           </ul>
         </footer>
       </section>


### PR DESCRIPTION
Fixing the link on the github pages site that is supposed to point to the documentation. Fixes https://github.com/instagrambot/instabot/issues/1075

Thanks for participating in Hacktoberfest 2019!